### PR TITLE
Add optional config `min_days_to_sync`

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -32,6 +32,10 @@ plugins:
       kind: date_iso8601
       label: Start Date
       description: Determines how much historical data will be extracted
+    - name: min_days_to_sync
+      kind: integer
+      label: Min days to sync
+      description: Optional - Determines the minimum number of days to sync (if not set it will always sync from the last state)
   loaders:
   - name: target-jsonl
     variant: andyh1203

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-upwork"
-version = "0.0.2"
+version = "0.1.1"
 description = "`tap-upwork` is a Singer tap for UpWork, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Joao Amaral"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-upwork"
-version = "0.0.1"
+version = "0.0.2"
 description = "`tap-upwork` is a Singer tap for UpWork, built with the Meltano Singer SDK."
 readme = "README.md"
 authors = ["Joao Amaral"]

--- a/tap_upwork/streams.py
+++ b/tap_upwork/streams.py
@@ -48,7 +48,8 @@ class ContractTimeReportStream(UpWorkStream):
         if 'min_days_to_sync' in self.config:
             start_date = min(
                 start_date,
-                pendulum.now() + timedelta(days=-int(self.config.get('min_days_to_sync')))
+                pendulum.now()
+                + timedelta(days=-int(self.config.get('min_days_to_sync'))),
             )
         params = {
             'filter': {
@@ -91,7 +92,8 @@ class TimeReportStream(UpWorkStream):
         if 'min_days_to_sync' in self.config:
             start_date = min(
                 start_date,
-                pendulum.now() + timedelta(days=-int(self.config.get('min_days_to_sync')))
+                pendulum.now()
+                + timedelta(days=-int(self.config.get('min_days_to_sync'))),
             )
         return {
             'filter': {

--- a/tap_upwork/streams.py
+++ b/tap_upwork/streams.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Optional, Dict, Any
 
 import pendulum
@@ -45,6 +45,11 @@ class ContractTimeReportStream(UpWorkStream):
         start_date = pendulum.instance(
             self.get_starting_timestamp(context) or pendulum.from_timestamp(0)
         )
+        if 'min_days_to_sync' in self.config:
+            start_date = min(
+                start_date,
+                pendulum.now() + timedelta(days=-int(self.config.get('min_days_to_sync')))
+            )
         params = {
             'filter': {
                 'organizationId_eq': self.config.get('organization_id'),
@@ -83,6 +88,11 @@ class TimeReportStream(UpWorkStream):
         start_date = pendulum.instance(
             self.get_starting_timestamp(context) or pendulum.from_timestamp(0)
         )
+        if 'min_days_to_sync' in self.config:
+            start_date = min(
+                start_date,
+                pendulum.now() + timedelta(days=-int(self.config.get('min_days_to_sync')))
+            )
         return {
             'filter': {
                 'organizationId_eq': self.config.get('organization_id'),

--- a/tests/unittests/test_stream.py
+++ b/tests/unittests/test_stream.py
@@ -9,9 +9,13 @@ from tap_upwork.streams import ContractTimeReportStream
 
 class TestContractTimeReportStream(TestCase):
     def setUp(self):
-        self.mock_contract_time_report_stream = create_autospec(ContractTimeReportStream, instance=True)
-        self.mock_contract_time_report_stream.get_url_params = partial(ContractTimeReportStream.get_url_params,
-                                                                       self.mock_contract_time_report_stream)
+        self.mock_contract_time_report_stream = create_autospec(
+            ContractTimeReportStream, instance=True
+        )
+        self.mock_contract_time_report_stream.get_url_params = partial(
+            ContractTimeReportStream.get_url_params,
+            self.mock_contract_time_report_stream,
+        )
 
     @patch('tap_upwork.streams.pendulum.now')
     @patch('tap_upwork.streams.pendulum.instance')

--- a/tests/unittests/test_stream.py
+++ b/tests/unittests/test_stream.py
@@ -1,0 +1,61 @@
+from functools import partial
+from unittest import TestCase
+from unittest.mock import patch, create_autospec
+
+import pendulum
+
+from tap_upwork.streams import ContractTimeReportStream
+
+
+class TestContractTimeReportStream(TestCase):
+    def setUp(self):
+        self.mock_contract_time_report_stream = create_autospec(ContractTimeReportStream, instance=True)
+        self.mock_contract_time_report_stream.get_url_params = partial(ContractTimeReportStream.get_url_params,
+                                                                       self.mock_contract_time_report_stream)
+
+    @patch('tap_upwork.streams.pendulum.now')
+    @patch('tap_upwork.streams.pendulum.instance')
+    def test_get_url_params(self, mock_instance, mock_now):
+        mock_now.return_value = pendulum.datetime(2023, 10, 30)
+        mock_instance.return_value = pendulum.datetime(2023, 10, 29)
+
+        self.mock_contract_time_report_stream.config = {
+            'organization_id': '12345',
+            'min_days_to_sync': 7,
+        }
+
+        expected_params = {
+            'filter': {
+                'organizationId_eq': '12345',
+                'timeReportDate_bt': {
+                    'rangeStart': '2023-10-23',
+                    'rangeEnd': '2023-10-30',
+                },
+            },
+            'pagination': {'first': 500},
+        }
+        result = self.mock_contract_time_report_stream.get_url_params(None, None)
+        self.assertEqual(result, expected_params)
+
+        # Test with next_page_token
+        expected_params['pagination']['after'] = 'token123'
+        result = self.mock_contract_time_report_stream.get_url_params(None, 'token123')
+        self.assertEqual(result, expected_params)
+
+        # Test without min_days_to_sync
+        self.mock_contract_time_report_stream.config = {
+            'organization_id': '12345',
+        }
+
+        expected_params = {
+            'filter': {
+                'organizationId_eq': '12345',
+                'timeReportDate_bt': {
+                    'rangeStart': '2023-10-29',
+                    'rangeEnd': '2023-10-30',
+                },
+            },
+            'pagination': {'first': 500},
+        }
+        result = self.mock_contract_time_report_stream.get_url_params(None, None)
+        self.assertEqual(result, expected_params)

--- a/tests/unittests/test_stream.py
+++ b/tests/unittests/test_stream.py
@@ -17,8 +17,9 @@ class TestContractTimeReportStream(TestCase):
     @patch('tap_upwork.streams.pendulum.instance')
     def test_get_url_params(self, mock_instance, mock_now):
         mock_now.return_value = pendulum.datetime(2023, 10, 30)
-        mock_instance.return_value = pendulum.datetime(2023, 10, 29)
+        mock_instance.return_value = pendulum.datetime(2023, 10, 25)
 
+        # Test with min_days_to_sync > state
         self.mock_contract_time_report_stream.config = {
             'organization_id': '12345',
             'min_days_to_sync': 7,
@@ -51,11 +52,20 @@ class TestContractTimeReportStream(TestCase):
             'filter': {
                 'organizationId_eq': '12345',
                 'timeReportDate_bt': {
-                    'rangeStart': '2023-10-29',
+                    'rangeStart': '2023-10-25',
                     'rangeEnd': '2023-10-30',
                 },
             },
             'pagination': {'first': 500},
         }
+        result = self.mock_contract_time_report_stream.get_url_params(None, None)
+        self.assertEqual(result, expected_params)
+
+        # Test without min_days_to_sync < state
+        self.mock_contract_time_report_stream.config = {
+            'organization_id': '12345',
+            'min_days_to_sync': 3,
+        }
+
         result = self.mock_contract_time_report_stream.get_url_params(None, None)
         self.assertEqual(result, expected_params)


### PR DESCRIPTION
Some upwork reports can be updated in the past and the `timeReportDate` (the filter state field) is not updated when it happens, so we add an optional field `min_days_to_sync` which forces the sync to collect more days in the past (if the saved state or start date is more recent). 

> Warning: This will collect more duplicates, but it will guarantee that the added/updated rows in the past will be collected.

## Tests

### Tap-Upwork (changing the config file to add and remove the `min_days_to_sync`)

```
tap-upwork --config config.json --discover > ./catalog.json
tap-upwork --config config.json --catalog catalog.json
```
### Meltano (adding and removing the `min_days_to_sync` in .env)

```
meltano elt tap-upwork target-jsonl
```

### Unittest

```
tests/unittests/test_stream.py::TestContractTimeReportStream::test_get_url_params PASSED 
```

### Core tests

```
collected 50 items                                                                                                                                                                                                                                                                                                                                                                                                         

tests/test_core.py ................................................                                                                                                                                                                                                                                                                                                                                                  [ 96%]
tests/unittests/test_client.py .                                                                                                                                                                                                                                                                                                                                                                                     [ 98%]
tests/unittests/test_stream.py .  
```